### PR TITLE
Automatically build Linux executables

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -31,7 +31,7 @@ jobs:
       with:
         push: false
         outputs: type=local,dest=bin
-        platforms: linux/amd64,linux/arm64,linux/armv7
+        platforms: linux/amd64,linux/arm64
 
     - name: Publish amd64 executables
       uses: actions/upload-artifact@v3
@@ -44,12 +44,6 @@ jobs:
       with:
         name: amcduke32_linux_arm64.zip
         path: bin/linux_arm64/*
-
-    - name: Publish armv7 executables
-      uses: actions/upload-artifact@v3
-      with:
-        name: amcduke32_linux_armv7.zip
-        path: bin/linux_armv7/*
 
     # TODO: automatically create a GitHub release when a tag is created
     # TODO: see about building Windows executables too

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -1,25 +1,28 @@
-name: Build amcduke32
+name: Build Linux
 
 on:
   # Allow manual runs
   workflow_dispatch:
   # Run on any push to `master`
   push:
-    branches: [ master ]
+    branches:
+    - master
   # Definitely run on any PR
   pull_request:
-    branches: [ master ]
+    branches:
+    - master
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       name: Check out repository
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
@@ -28,13 +31,25 @@ jobs:
       with:
         push: false
         outputs: type=local,dest=bin
-        platforms: linux/amd64,linux/arm64
-        
-    - name: Publish build artifacts
+        platforms: linux/amd64,linux/arm64,linux/armv7
+
+    - name: Publish amd64 executables
       uses: actions/upload-artifact@v3
       with:
-        name: amcduke32
-        path: bin
+        name: amcduke32_linux_amd64.zip
+        path: bin/linux_amd64/*
+
+    - name: Publish arm64 executables
+      uses: actions/upload-artifact@v3
+      with:
+        name: amcduke32_linux_arm64.zip
+        path: bin/linux_arm64/*
+
+    - name: Publish armv7 executables
+      uses: actions/upload-artifact@v3
+      with:
+        name: amcduke32_linux_armv7.zip
+        path: bin/linux_armv7/*
 
     # TODO: automatically create a GitHub release when a tag is created
     # TODO: see about building Windows executables too

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
       name: Check out repository
 
     - name: Set up QEMU

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /amcduke32
 COPY . /amcduke32/
 
 RUN apt-get update \
-  && apt-get install \
+  && apt-get install -y \
     build-essential \
     nasm \
     libgl1-mesa-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN apt-get update \
   
 FROM scratch AS distrib
 
-COPY from=builder /amcduke32/amcsquad /amcduke32/mapster32 /
+COPY --from=builder /amcduke32/amcsquad /amcduke32/mapster32 /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS buildenv
+FROM ubuntu:22.04 AS builder
 ARG BUILDOPTS
 ENV BUILDOPTS=${BUILDOPTS}
 WORKDIR /amcduke32

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM ubuntu:22.04 AS builder
-
+FROM ubuntu:22.04 AS buildenv
+ARG BUILDOPTS
+ENV BUILDOPTS=${BUILDOPTS}
 WORKDIR /amcduke32
 COPY . /amcduke32/
 
 RUN apt-get update \
-  && apt-get install -y \
+  && apt-get install --no-install-recommends -y \
     build-essential \
+    git \
     nasm \
     libgl1-mesa-dev \
     libglu1-mesa-dev \
@@ -19,8 +21,7 @@ RUN apt-get update \
     libvpx-dev \
     libgtk2.0-dev \
     freepats \
-  && make
-  
+  && make ${BUILDOPTS}
+   
 FROM scratch AS distrib
-
 COPY --from=builder /amcduke32/amcsquad /amcduke32/mapster32 /


### PR DESCRIPTION
This will automatically build Linux executables for `amcsquad` and `mapster32` on every push to `master` as well as PRs.